### PR TITLE
Adding the lecture videos embeds to the documentation

### DIFF
--- a/docs/source/codependence/introduction.rst
+++ b/docs/source/codependence/introduction.rst
@@ -6,6 +6,28 @@ Introduction
 
 This module includes implementations of codependence metrics.
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/YyMouLPj2QA"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
+
 According to Lopez de Prado: "Two random variables are codependent when knowing the value of one helps us determine the value of the other.
 This should not be confounded with the notion of causality."
 

--- a/docs/source/cointegration_approach/cointegration_tests.rst
+++ b/docs/source/cointegration_approach/cointegration_tests.rst
@@ -12,6 +12,28 @@
 Tests for Cointegration
 =======================
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/1zz91G0nR14?start=170"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
+
 According to Ernest P. Chan:
 "The mathematical description of a mean-reverting price series is that the change of the price series
 in the next period is proportional to the difference between the mean price and the current price. This

--- a/docs/source/cointegration_approach/introduction.rst
+++ b/docs/source/cointegration_approach/introduction.rst
@@ -9,6 +9,28 @@
 Introduction
 ============
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/1zz91G0nR14"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
+
 Mean-reverting processes and events often occur in nature. Observations of the processes that have a
 mean-reverting nature tend to move to their average value over time. However, as mentioned in
 the work of E.P. Chan, most financial price series are not mean-reverting.

--- a/docs/source/cointegration_approach/minimum_profit.rst
+++ b/docs/source/cointegration_approach/minimum_profit.rst
@@ -10,6 +10,28 @@
 Minimum Profit Optimization
 ===========================
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/1zz91G0nR14?start=928"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
+
 Introduction
 ############
 

--- a/docs/source/cointegration_approach/minimum_profit_simulation.rst
+++ b/docs/source/cointegration_approach/minimum_profit_simulation.rst
@@ -9,6 +9,28 @@
 Simulation of Cointegratred Series
 ==================================
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/1zz91G0nR14?start=662"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
+
 This module allows users to simulate:
 
 - AR(1) processes

--- a/docs/source/cointegration_approach/sparse_mr_portfolio.rst
+++ b/docs/source/cointegration_approach/sparse_mr_portfolio.rst
@@ -22,6 +22,28 @@
 Sparse Mean-reverting Portfolio Selection
 =========================================
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/IP7R-gnDF9w"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
+
 Introduction
 ############
 

--- a/docs/source/copula_approach/copula_brief_intro.rst
+++ b/docs/source/copula_approach/copula_brief_intro.rst
@@ -16,6 +16,28 @@
 A Practical Introduction to Copula
 ==================================
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/hLV5Roa_Bek"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
+
 Instead of starting with a formal definition of copula with mathematical rigor, let's start by doing the following
 calculations to try to temporarily bypass it. The mathematical definition may not help much unless we have an idea
 of where the copula comes from.

--- a/docs/source/copula_approach/mispricing_index_strategy.rst
+++ b/docs/source/copula_approach/mispricing_index_strategy.rst
@@ -4,6 +4,28 @@
 Mispricing Index Trading Strategy
 =================================
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/t99uCFQL5KI"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
+
 .. Note::
     The following strategy closely follows the implementations:
 

--- a/docs/source/copula_approach/partner_selection.rst
+++ b/docs/source/copula_approach/partner_selection.rst
@@ -13,6 +13,28 @@
 Vine Copula Partner Selection
 =============================
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/qg-idKbPH24"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
+
 This module contains implementation of the four partner selection approaches
 mentioned in Section 3.1.1 of Statistical Arbitrage with Vine Copulas.
 

--- a/docs/source/copula_approach/vine_copula_intro.rst
+++ b/docs/source/copula_approach/vine_copula_intro.rst
@@ -12,6 +12,28 @@
 A Practical Introduction to Vine Copula
 =======================================
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/FB6tNgCZSbo"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
+
 Copula is a great statistical tool to study the relation among multiple random variables: By focusing on the joint
 cumulative density of quantiles of marginals, we can bypass the idiosyncratic features of marginal distributions and
 directly look at how they are "related".

--- a/docs/source/distance_approach/distance_approach.rst
+++ b/docs/source/distance_approach/distance_approach.rst
@@ -11,6 +11,27 @@
 Distance Approach
 =================
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/sKgDeqI39b4"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+    </div>
+
 The distance approach was introduced in the paper by Gatev et al. (2006), and it is one of the most cited
 pairs trading papers at the time of writing this documentation. The approach described in the paper is
 the following: First, a historical period is defined, cumulative returns for assets in this period are

--- a/docs/source/distance_approach/pearson_approach.rst
+++ b/docs/source/distance_approach/pearson_approach.rst
@@ -14,6 +14,28 @@
 Pearson Approach
 ================
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/fvTQAnjgIaA"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
+
 After the distance approach was introduced in the paper by Gatev et al. (2006), a lot of research has been
 conducted to further develop the original distance approach. One of the adjustments is the Pearson correlation
 approach proposed by Chen et al.(2012). In this paper, the authors use the same data set and time frame as

--- a/docs/source/hedge_ratios/hedge_ratios.rst
+++ b/docs/source/hedge_ratios/hedge_ratios.rst
@@ -4,6 +4,28 @@
 Hedge Ratio Calculations
 ========================
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/odh5rH3WYJM"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
+
 There are various ways to find mean-reverting spread, including distance, cointegration, copula and ML approach.
 In the next step, when a trade signal is generated (Z-score > or < then threshold value), a researcher needs to understand
 how to trade the spread. How many units of X stock to buy and how many units of Y to sell.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,26 @@ Statistical Arbitrage Laboratory (ArbitrageLab)
 
 ArbitrageLab is a python library that enables traders who want to exploit mean-reverting portfolios by providing a complete set of algorithms from the best academic journals.
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/DgU1lSdH3vM"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+    </div>
+
 ----
 
 Documentation & Tutorials

--- a/docs/source/ml_approach/introduction.rst
+++ b/docs/source/ml_approach/introduction.rst
@@ -13,6 +13,27 @@
 Introduction
 ============
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/R22JR4tqqqs"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
 
 The success of a Pairs Trading strategy highly depends on finding the right pairs.
 But with the increasing availability of data, more traders manage to spot interesting 

--- a/docs/source/ml_approach/spread_modeling.rst
+++ b/docs/source/ml_approach/spread_modeling.rst
@@ -11,6 +11,28 @@
 Spread Modeling
 ===============
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/z6x7pLDwBVM"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
+
 Introduction
 ############
 

--- a/docs/source/optimal_mean_reversion/ou_model.rst
+++ b/docs/source/optimal_mean_reversion/ou_model.rst
@@ -8,6 +8,29 @@
 ==========================================
 Trading Under the Ornstein-Uhlenbeck Model
 ==========================================
+
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/Fllb9C7p7kE"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
+
 .. warning::
 
     Alongside with Leung's research we are using :math:`\theta` for mean and :math:`\mu` for mean-reversion

--- a/docs/source/other_approaches/kalman_filter.rst
+++ b/docs/source/other_approaches/kalman_filter.rst
@@ -8,6 +8,28 @@
 Kalman Filter
 =============
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/YavO2-sNVcs"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
+
 Introduction
 ############
 

--- a/docs/source/other_approaches/pca_approach.rst
+++ b/docs/source/other_approaches/pca_approach.rst
@@ -8,6 +8,28 @@
 PCA Approach
 ============
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/IVAmm34eKWQ"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
+
 Introduction
 ############
 

--- a/docs/source/stochastic_control_approach/introduction.rst
+++ b/docs/source/stochastic_control_approach/introduction.rst
@@ -10,6 +10,28 @@
 Introduction
 ============
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/P0r-Vqzpk5k"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
+
 Modeling asset pricing dynamics with the Ornstein-Uhlenbeck process
 ###################################################################
 

--- a/docs/source/stochastic_control_approach/optimal_convergence.rst
+++ b/docs/source/stochastic_control_approach/optimal_convergence.rst
@@ -10,6 +10,28 @@
 Optimal Convergence
 ===================
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/U-jyYwHlwh0"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
+
 Introduction
 ############
 

--- a/docs/source/stochastic_control_approach/ou_model_jurek.rst
+++ b/docs/source/stochastic_control_approach/ou_model_jurek.rst
@@ -10,6 +10,28 @@
 OU Model Jurek
 ==============
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/P0r-Vqzpk5k?start=601"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
+
 Introduction
 ############
 

--- a/docs/source/stochastic_control_approach/ou_model_mudchanatongsuk.rst
+++ b/docs/source/stochastic_control_approach/ou_model_mudchanatongsuk.rst
@@ -11,6 +11,28 @@
 OU Model Mudchanatongsuk
 ========================
 
+.. raw:: html
+
+    <div style="position: relative;
+                padding-bottom: 56.25%;
+                margin-bottom: 5%;
+                height: 0;
+                overflow: hidden;
+                max-width: 100%;
+                height: auto;">
+
+        <iframe src="https://www.youtube.com/embed/P0r-Vqzpk5k?start=180"
+                frameborder="0"
+                allowfullscreen
+                style="position: absolute;
+                       top: 0;
+                       left: 0;
+                       width: 100%;
+                       height: 100%;">
+        </iframe>
+        <br/>
+    </div>
+
 Introduction
 ############
 


### PR DESCRIPTION
## Purpose
Add the corresponding lectures youtube embeds to the documentation

## Approach
It allows for better comprehension of the material outlined in the documentation.


## Checklist
_Make sure you did the following (if applicable):_
- [X] Built and reviewed the docs.
- [ ] Added a note to the [changelog](https://github.com/hudson-and-thames/arbitragelab/blob/develop/docs/source/changelog.rst).


